### PR TITLE
Prevent failed unload event registration

### DIFF
--- a/addon/services/popout-parent.js
+++ b/addon/services/popout-parent.js
@@ -53,15 +53,18 @@ export default Ember.Service.extend({
 
     const { popouts, popoutNames } = this.getProperties('popouts', 'popoutNames');
 
-    popouts[id] = reference;
-    popoutNames.pushObject(id);
+    if (reference) {
+      popouts[id] = reference;
+      popoutNames.pushObject(id);
 
-    reference.onunload = function() {
-      Ember.run(function() {
-        delete popouts[id];
-        popoutNames.removeObject(id);
-      });
-    };
+      reference.onunload = function() {
+        Ember.run(function() {
+          delete popouts[id];
+          popoutNames.removeObject(id);
+        });
+      };
+    }
+
     return reference;
   },
 


### PR DESCRIPTION
If the window popout is blocked by the browser, the window reference
will be null, causing `reference.onunload` to be undefined. This
adds a guard to ensure that reference exists.