### PR TITLE
Check if popout is blank before unloading

### DIFF
--- a/addon/services/popout-parent.js
+++ b/addon/services/popout-parent.js
@@ -57,10 +57,12 @@ export default Ember.Service.extend({
       popoutNames.pushObject(id);
 
       reference.onunload = function() {
-        Ember.run(function() {
-          delete popouts[id];
-          popoutNames.removeObject(id);
-        });
+        if (reference.location.href !== 'about:blank') {
+          Ember.run(function() {
+            delete popouts[id];
+            popoutNames.removeObject(id);
+          });
+        }
       };
     }
 


### PR DESCRIPTION
I noticed that when opening a popout it would open with "about:blank" as the url and then transition to the correct url. This was causing the `unload` event to fire immediately, which would remove the reference from the list of open popouts and popoutNames.

This should fix the issue.